### PR TITLE
fix: remove init method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+*.log
+temp
+.vscode

--- a/index.js
+++ b/index.js
@@ -15,11 +15,6 @@ function ScriptPort() {
 
 util.inherits(ScriptPort, Port);
 
-ScriptPort.prototype.init = function init() {
-    Port.prototype.init.apply(this, arguments);
-    this.latency = this.counter && this.counter('average', 'lt', 'Latency');
-};
-
 // skip creating unnecessary decoding stream, as same message is looped back by exec
 ScriptPort.prototype.decode = function decode() {
     return null;


### PR DESCRIPTION
Remove init method because:
* the dafault Port.prototype.init methods to be called directly which returns promise
* this.latency is not needed anymore with the newer versions of ut-bus