### PR TITLE
Script port allows usage of port context

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = function({parent}) {
         return Promise.resolve()
             .then(() => parent && parent.prototype.start.apply(this, params))
             .then(result => {
-                this.pull(this.exec);
+                this.pull(this.exec, this.config.context);
                 return result;
             });
     };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lodash.merge": "4.6.0"
   },
   "devDependencies": {
-    "ut-tools": "^5.23.2"
+    "ut-tools": "^5.32.10"
   },
   "description": "UT port script module",
   "scripts": {
@@ -13,6 +13,7 @@
     "release": "ut-release",
     "changelog": "ut-changelog",
     "check": "ut-check",
+    "precover": "ut-precover",
     "cover": "ut-cover",
     "lint-js": "ut-lint-js .",
     "postpublish": "ut-postpublish",


### PR DESCRIPTION
The script port now passes this.config.context to the port pull method which allows the script port to use the port context.